### PR TITLE
Add a script and instructions for testing HTTPS-only features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ The app will be available at [localhost:3333](http://localhost:3333).
 
 Test that the code is still clean and working with `npm test`.
 
+### Testing HTTPS-only features
+
+Features like service workers only work with HTTPS.  If you don't want to go
+through the hassle of setting that up, you can test these features by uploading
+a built version of the app to GitHub Pages, which offers free HTTPS.
+
+Adjacent to wherever you cloned this directory, clone the repository again, but
+with a different name:
+
+```sh
+git clone --branch gh-pages --single-branch \
+  git@github.com:jacksonrayhamilton/yugioh-calculator-2016.git \
+  yugioh-calculator-2016-gh-pages
+```
+
+Afterwards, the directory structure of the place on your computer where you
+store your repositories should look like this:
+
+```
+yugioh-calculator-2016/
+yugioh-calculator-2016-gh-pages/
+```
+
+Then, within the `yugioh-calculator-2016/` directory, run `scripts/gh-pages.sh`
+to build and deploy the app to GitHub pages.  Visit the app at
+https://jacksonrayhamilton.github.io/yugioh-calculator-2016/ (but replace
+"jacksonrayhamilton" with the name of your GitHub account).
+
 ## Deployment
 
 Create a ".env" file at the project root with contents similar to the following

--- a/brunch-config.js
+++ b/brunch-config.js
@@ -45,7 +45,8 @@ module.exports = {
           'public/**/*.*',
           'public/**/!(*map*)'
         ],
-        stripPrefix: 'public'
+        stripPrefix: 'public',
+        replacePrefix: process.env.YC_ENV === 'gh-pages' ? '/yugioh-calculator-2016' : ''
       }
     }
   },

--- a/scripts/gh-pages.sh
+++ b/scripts/gh-pages.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Deploy the website via GitHub Pages, to test HTTPS-only features (like service
+# workers).
+
+# Normalize execution location.
+FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$FILE_DIR/../"
+
+# LOCAL_BUILD_DIR must end with a "/".
+LOCAL_BUILD_DIR=public/
+
+# It's easier to deploy to GitHub Pages in a separate directory.
+DEPLOYMENT_DIR="$FILE_DIR/../../yugioh-calculator-2016-gh-pages/"
+
+# Build production site to build directory.
+YC_ENV='gh-pages' npm run build
+
+# Copy local production build files to remote.
+rsync --verbose --archive --update --delete \
+      --exclude=.git \
+      "$LOCAL_BUILD_DIR" \
+      "$DEPLOYMENT_DIR"
+
+cd "$DEPLOYMENT_DIR"
+git add -A
+git commit -m 'Automatically-generated commit.'
+git push -f origin gh-pages


### PR DESCRIPTION
Since none of the options for testing service workers on a local network on an iOS and Android device described [here](https://stackoverflow.com/questions/34160509/options-for-testing-service-workers-via-http) worked for me, I opted for the stupid yet relatively painless option of uploading the application to GitHub pages.  This adds support and instructions for how to do that.